### PR TITLE
Use team order attribute to order driver selector

### DIFF
--- a/src/driver-selector/DriverSelectorContainer.jsx
+++ b/src/driver-selector/DriverSelectorContainer.jsx
@@ -43,8 +43,21 @@ DriverSelectorContainer.defaultProps = {
 };
 
 function mapStateToProps(state) {
+  const driversMap = state.session.get('drivers');
+  const localDrivers = driversMap.keySeq().toArray();
+
+  localDrivers.sort((a, b) => {
+    const driverA = driversMap.get(a);
+    const driverB = driversMap.get(b);
+
+    const driverATeamOrder = driverA.get('teamOrder');
+    const driverBTeamOrder = driverB.get('teamOrder');
+
+    return driverATeamOrder === driverBTeamOrder ? driverA.get('number') - driverB.get('number') : driverATeamOrder - driverBTeamOrder;
+  });
+
   return {
-    drivers: state.session.get('drivers').keySeq().toArray(),
+    drivers: localDrivers,
     selectedDriver: state.selectedDriver.get('selectedDriver'),
     selectedOpponent: state.selectedDriver.get('selectedOpponent'),
   };

--- a/src/session-data/session-reducer.js
+++ b/src/session-data/session-reducer.js
@@ -65,7 +65,8 @@ function appendDriverMessage(drivers, msg) {
     driver = driver.set('color', `#${d.color}`)
               .set('number', d.number)
               .set('team', d.team)
-              .set('tla', d.tla);
+              .set('tla', d.tla)
+              .set('teamOrder', d.teamOrder);
     updatedDrivers = updatedDrivers.set(d.tla, driver);
   });
 

--- a/src/session-data/session-reducer.test.js
+++ b/src/session-data/session-reducer.test.js
@@ -42,6 +42,7 @@ describe('session reducer', () => {
           number: '42',
           team: 'racing',
           tla: 'TST',
+          teamOrder: '2',
         },
       ] }]);
 
@@ -53,6 +54,7 @@ describe('session reducer', () => {
     assert(state.get('drivers').get('TST').get('number').should.equal('42'));
     assert(state.get('drivers').get('TST').get('team').should.equal('racing'));
     assert(state.get('drivers').get('TST').get('tla').should.equal('TST'));
+    assert(state.get('drivers').get('TST').get('teamOrder').should.equal('2'));
   });
 
   it('adds a new driver to the session with first lap', () => {


### PR DESCRIPTION
Depends on teamOrder attribute on the driver event which will be provided by PR #2 on the server project. Also not sure how to test DriverSelectorContainer, any pointers?